### PR TITLE
[feat] #17 문장부호 퀴즈 View 구현 

### DIFF
--- a/LearnDot/ContentView.swift
+++ b/LearnDot/ContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var coordinator = NavigationCoordinator()
+    @StateObject private var punctuationViewModel = PunctuationQuizViewModel()
     
     var body: some View {
         NavigationStack(path: $coordinator.path) {
@@ -23,6 +24,12 @@ struct ContentView: View {
                         WordQuizView(level: level, category: category)
                     case .result(let isCorrect, let level, let category, let correctAnswer, let braillePattern):
                         WordQuizResultView(isCorrect: isCorrect, level: level, category: category, correctAnswer: correctAnswer, braillePattern: braillePattern)
+                    case .PunctuationQuiz:
+                        PunctuationQuizView()
+                            .environmentObject(punctuationViewModel)
+                    case .PunctuationResult(let isCorrect):
+                        PunctuationQuizResultView(isCorrect: isCorrect)
+                            .environmentObject(punctuationViewModel)
                     }
                 }
         }

--- a/LearnDot/Resources/NavigationCoordinator.swift
+++ b/LearnDot/Resources/NavigationCoordinator.swift
@@ -29,5 +29,7 @@ enum AppDestination: Hashable {
     case wordLevel
     case wordCategory(DifficultyLevel)
     case wordQuiz(DifficultyLevel, WordCategory)
+    case PunctuationQuiz
+    case PunctuationResult(Bool) // isCorrect
     case result(Bool, DifficultyLevel, WordCategory, String, String) // isCorrect, level, category, correctAnswer, braillePattern
 }

--- a/LearnDot/ViewModels/PunctuationQuizViewModel.swift
+++ b/LearnDot/ViewModels/PunctuationQuizViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  PunctuationQuizViewModel.swift
+//  LearnDot
+//
+//  Created by 신혜연 on 6/11/25.
+//
+
+import Foundation
+
+class PunctuationQuizViewModel: ObservableObject {
+    
+    let punctuationData: [BrailleWord] = [
+        BrailleWord(korean: "온점 (.)", braillePattern: "⠲"),
+        BrailleWord(korean: "물음표 (?)", braillePattern: "⠦"),
+        BrailleWord(korean: "느낌표 (!)", braillePattern: "⠖"),
+        BrailleWord(korean: "반점 (,)", braillePattern: "⠐"),
+        BrailleWord(korean: "붙임표 (-)", braillePattern: "⠤"),
+        BrailleWord(korean: "빼기 (-)", braillePattern: "⠔"),
+        BrailleWord(korean: "줄표 (—)", braillePattern: "⠤⠤"),
+        BrailleWord(korean: "물결표 (~)", braillePattern: "⠈⠔"),
+        BrailleWord(korean: "별표 (*)", braillePattern: "⠐⠔"),
+        BrailleWord(korean: "여는 큰따옴표 (“)", braillePattern: "⠠⠦"),
+        BrailleWord(korean: "닫는 큰따옴표 (”)", braillePattern: "⠴"),
+        BrailleWord(korean: "여는 작은따옴표 (‘)", braillePattern: "⠠⠦"),
+        BrailleWord(korean: "닫는 작은따옴표 (’)", braillePattern: "⠴⠄"),
+        BrailleWord(korean: "쌍점 (:)", braillePattern: "⠐⠂"),
+        BrailleWord(korean: "세미콜론 (;)", braillePattern: "⠰⠆"),
+        BrailleWord(korean: "줄임표 (…)", braillePattern: "⠠⠠⠠")
+    ]
+    
+    @Published var currentQuiz: BrailleWord? = nil
+    
+    init() {
+        generateNewQuiz()
+    }
+    
+    func generateNewQuiz() {
+        currentQuiz = punctuationData.randomElement()
+    }
+    
+    func isAnswerCorrect(selectedDotsArray: [[Int]]) -> Bool {
+        guard let correctPattern = currentQuiz?.braillePattern else { return false }
+        
+        let correctDotArrays = convertBraillePatternToDotArrays(correctPattern)
+        
+        print("🔍 정답 패턴: \(correctPattern)")
+        print("✅ 정답 dot 배열: \(correctDotArrays)")
+        print("📝 입력 dot 배열: \(selectedDotsArray)")
+        
+        if selectedDotsArray.count != correctDotArrays.count { return false }
+        
+        for (inputDots, correctDots) in zip(selectedDotsArray, correctDotArrays) {
+            if Set(inputDots) != Set(correctDots) {
+                print("❌ 불일치: \(inputDots) vs \(correctDots)")
+                return false
+            }
+        }
+        return true
+    }
+    
+    func convertBraillePatternToDotArrays(_ pattern: String) -> [[Int]] {
+        pattern.map { brailleChar in
+            let scalar = brailleChar.unicodeScalars.first!.value
+            let bits = Int(scalar - 0x2800)
+            var activeDots: [Int] = []
+            for i in 0..<6 {
+                if (bits & (1 << i)) != 0 {
+                    activeDots.append(i+1)
+                }
+            }
+            return activeDots
+        }
+    }
+}

--- a/LearnDot/Views/HomeView.swift
+++ b/LearnDot/Views/HomeView.swift
@@ -51,7 +51,7 @@ struct HomeView: View {
                             title: "문장부호 점형 학습",
                             description: "문장부호 퀴즈 맞추기"
                         ) {
-                            
+                            coordinator.push(AppDestination.PunctuationQuiz)
                         }
                     }
                     .padding(.top, 30)
@@ -61,8 +61,4 @@ struct HomeView: View {
             }
             .ignoresSafeArea()
         }
-}
-
-#Preview {
-    HomeView()
 }

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizResultView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizResultView.swift
@@ -1,0 +1,145 @@
+//
+//  PunctuationQuizResultView.swift
+//  LearnDot
+//
+//  Created by 신혜연 on 6/11/25.
+//
+
+import SwiftUI
+
+struct PunctuationQuizResultView: View {
+    @EnvironmentObject var viewModel: PunctuationQuizViewModel
+    @Environment(NavigationCoordinator.self) private var coordinator
+    
+    let isCorrect: Bool
+    
+    var body: some View {
+        let correctQuiz = viewModel.currentQuiz!
+        
+        let dotArrays = viewModel.convertBraillePatternToDotArrays(correctQuiz.braillePattern)
+        let dotNumbersText = dotArrays
+            .map { $0.sorted().map { String($0) }.joined(separator: "-") }
+            .joined(separator: ", ")
+        
+        ZStack {
+            Color.black00
+                .ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                Spacer().frame(height: 137)
+                
+                if isCorrect {
+                    VStack(spacing: 13){
+                        Text("정답입니다!🎉")
+                            .font(.mainTextBold32)
+                            .foregroundStyle(.white00)
+                        
+                        Text("다음 문제에도 도전해볼까요?")
+                            .font(.mainTextSemiBold15)
+                            .foregroundStyle(.gray02)
+                    }
+                } else {
+                    VStack(spacing: 0){
+                        Text("오답입니다 😭")
+                            .font(.mainTextBold32)
+                            .foregroundStyle(.white00)
+                        
+                        Group {
+                            Text("정답의 점형 번호는 ")
+                                .foregroundStyle(.white00)
+                            + Text(dotNumbersText)
+                                .foregroundStyle(.blue00)
+                            + Text(" 입니다.")
+                                .foregroundStyle(.white00)
+                        }
+                        .font(.mainTextSemiBold20)
+                        .padding(.top, 8)
+                        
+                        Text("다음 문제는 맞춰봐요!")
+                            .font(.mainTextSemiBold15)
+                            .foregroundStyle(.gray02)
+                            .padding(.top, 8)
+                    }
+                }
+                
+                Spacer().frame(height: 87)
+                
+                VStack(spacing: 68) {
+                    RoundedRectangle(cornerRadius: 20)
+                        .foregroundStyle(.gray06)
+                        .frame(width: 240, height: 72)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 20)
+                                .stroke(Color.gray, lineWidth: 1)
+                        )
+                        .overlay {
+                            Text(correctQuiz.korean)
+                                .font(.mainTextSemiBold24)
+                                .foregroundStyle(.white00)
+                        }
+                    
+                    let dotArrays = viewModel.convertBraillePatternToDotArrays(correctQuiz.braillePattern)
+                    HStack(spacing: 12) {
+                        ForEach(dotArrays.indices, id: \.self) { index in
+                            DotCellView(dotIndexes: dotArrays[index])
+                        }
+                    }
+                }
+                .padding(.top, 20)
+                
+                
+                Spacer().frame(height: 96)
+                
+                HStack(spacing: 17) {
+                    Button {
+                        coordinator.popToRoot()
+                    } label: {
+                        QuitButtonCard()
+                    }
+                    
+                    Button{
+                        viewModel.generateNewQuiz()
+                        coordinator.push(AppDestination.PunctuationQuiz)
+                    } label: {
+                        NextButtonCard()
+                    }
+                }
+                
+                Spacer().frame(height: 80)
+            }
+        }
+    }
+}
+
+struct DotCellView: View {
+    let dotIndexes: [Int]
+
+    var body: some View {
+        let visualIndexToDotNumber = [0: 0, 1: 3, 2: 1, 3: 4, 4: 2, 5: 5]
+        VStack(spacing: 6) {
+            HStack(spacing: 6) {
+                dotCircle(index: 0)
+                dotCircle(index: 1)
+            }
+            HStack(spacing: 6) {
+                dotCircle(index: 2)
+                dotCircle(index: 3)
+            }
+            HStack(spacing: 6) {
+                dotCircle(index: 4)
+                dotCircle(index: 5)
+            }
+        }
+        .padding(8)
+        .background(Color.black00)
+    }
+
+    @ViewBuilder
+    private func dotCircle(index: Int) -> some View {
+        let dotIndexMapping = [0, 3, 1, 4, 2, 5]
+        let checkIndex = dotIndexMapping[index] + 1
+        Circle()
+            .fill(dotIndexes.contains(checkIndex) ? Color.white00 : Color.gray05)
+            .frame(width: 20, height: 20)
+    }
+}

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
@@ -1,0 +1,121 @@
+//
+//  PunctuationQuizView.swift
+//  LearnDot
+//
+//  Created by 신혜연 on 6/3/25.
+//
+
+import SwiftUI
+
+struct PunctuationQuizView: View {
+    
+    @State private var selectedDots: Set<Int> = []
+    
+    var body: some View {
+        ZStack {
+            Color.black00
+                .ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                Text("다음 문장부호의 점자를 찍어보세요.")
+                    .font(.mainTextBold24)
+                    .foregroundStyle(.blue00)
+                
+                RoundedRectangle(cornerRadius: 20)
+                    .foregroundStyle(.gray06)
+                    .frame(width: 240, height: 72)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20)
+                            .stroke(Color.gray, lineWidth: 1)
+                    )
+                    .overlay {
+                        Text(". 온점")
+                            .font(.mainTextSemiBold24)
+                            .foregroundStyle(.white00)
+                    }
+                    .padding(.top, 12)
+                
+                ZStack {
+                    HStack(spacing: 26) {
+                        Button {
+                            // 왼쪽 버튼 동작
+                        } label: {
+                            Image(systemName: "chevron.left")
+                                .frame(width: 41, height: 70)
+                                .foregroundColor(.gray00)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 20)
+                                        .stroke(Color.blue00, lineWidth: 2)
+                                )
+                        }
+                        
+                        Spacer()
+                        
+                        Button {
+                            // 오른쪽 버튼 동작
+                        } label: {
+                            Image(systemName: "chevron.right")
+                                .frame(width: 41, height: 70)
+                                .foregroundColor(.gray00)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 20)
+                                        .stroke(Color.blue00, lineWidth: 2)
+                                )
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    
+                    LazyVGrid(columns: [GridItem(), GridItem()], spacing: 26) {
+                        ForEach(0..<6) { index in
+                            Circle()
+                                .fill(selectedDots.contains(index) ? Color.white00 : Color.gray05)
+                                .frame(width: 100, height: 100)
+                                .onTapGesture {
+                                    if selectedDots.contains(index) {
+                                        selectedDots.remove(index)
+                                    } else {
+                                        selectedDots.insert(index)
+                                    }
+                                }
+                        }
+                    }
+                    .padding(.horizontal, 83)
+                }
+                .padding(.top, 42)
+                
+                HStack(spacing: 17) {
+                    Button {
+                        
+                    } label: {
+                        RoundedRectangle(cornerRadius: 20)
+                            .foregroundStyle(.gray01)
+                            .frame(width: 168, height: 64)
+                            .overlay {
+                                Text("다시쓰기")
+                                    .font(.mainTextBold24)
+                                    .foregroundStyle(.black00)
+                            }
+                    }
+                    
+                    Button {
+                        
+                    } label: {
+                        RoundedRectangle(cornerRadius: 20)
+                            .foregroundStyle(.blue01)
+                            .frame(width: 168, height: 64)
+                            .overlay {
+                                Text("작성완료")
+                                    .font(.mainTextBold24)
+                                    .foregroundStyle(.white00)
+                            }
+                    }
+                }
+                .padding(.top, 46)
+            }
+        }
+    }
+}
+
+#Preview {
+    PunctuationQuizView()
+}

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
@@ -8,10 +8,17 @@
 import SwiftUI
 
 struct PunctuationQuizView: View {
+    @Environment(NavigationCoordinator.self) private var coordinator
+    @EnvironmentObject var viewModel: PunctuationQuizViewModel
+
+    @State private var selectedDotsArray: [[Int]] = [[]]
+    @State private var currentCellIndex: Int = 0
     
-    @State private var selectedDots: Set<Int> = []
+    let indexToDotNumber = [1, 4, 2, 5, 3, 6]
     
     var body: some View {
+        let isSubmitDisabled = selectedDotsArray.allSatisfy { $0.isEmpty }
+        
         ZStack {
             Color.black00
                 .ignoresSafeArea()
@@ -21,38 +28,51 @@ struct PunctuationQuizView: View {
                     .font(.mainTextBold24)
                     .foregroundStyle(.blue00)
                 
-                RoundedRectangle(cornerRadius: 20)
-                    .foregroundStyle(.gray06)
-                    .frame(width: 240, height: 72)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 20)
-                            .stroke(Color.gray, lineWidth: 1)
-                    )
-                    .overlay {
-                        Text(". 온점")
-                            .font(.mainTextSemiBold24)
-                            .foregroundStyle(.white00)
-                    }
-                    .padding(.top, 12)
+                if let quiz = viewModel.currentQuiz {
+                    RoundedRectangle(cornerRadius: 20)
+                        .foregroundStyle(.gray06)
+                        .frame(width: 240, height: 72)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 20)
+                                .stroke(Color.gray, lineWidth: 1)
+                        )
+                        .overlay {
+                            Text(quiz.korean)
+                                .font(.mainTextSemiBold24)
+                                .foregroundStyle(.white00)
+                        }
+                        .padding(.top, 12)
+                }
                 
                 ZStack {
                     HStack(spacing: 26) {
-                        Button {
-                            // 왼쪽 버튼 동작
-                        } label: {
-                            Image(systemName: "chevron.left")
+                        if currentCellIndex > 0 {
+                            Button {
+                                currentCellIndex -= 1
+                            } label: {
+                                Image(systemName: "chevron.left")
+                                    .frame(width: 41, height: 70)
+                                    .foregroundColor(.gray00)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 20)
+                                            .stroke(Color.blue00, lineWidth: 2)
+                                    )
+                            }
+                        } else {
+                            Color.clear
                                 .frame(width: 41, height: 70)
-                                .foregroundColor(.gray00)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 20)
-                                        .stroke(Color.blue00, lineWidth: 2)
-                                )
                         }
                         
                         Spacer()
                         
                         Button {
-                            // 오른쪽 버튼 동작
+                            if !selectedDotsArray[currentCellIndex].isEmpty {
+                                currentCellIndex += 1
+                                
+                                if currentCellIndex >= selectedDotsArray.count {
+                                    selectedDotsArray.append([])
+                                }
+                            }
                         } label: {
                             Image(systemName: "chevron.right")
                                 .frame(width: 41, height: 70)
@@ -67,14 +87,15 @@ struct PunctuationQuizView: View {
                     
                     LazyVGrid(columns: [GridItem(), GridItem()], spacing: 26) {
                         ForEach(0..<6) { index in
+                            let dotNumber = indexToDotNumber[index]
                             Circle()
-                                .fill(selectedDots.contains(index) ? Color.white00 : Color.gray05)
+                                .fill(selectedDotsArray[currentCellIndex].contains(dotNumber) ? Color.white00 : Color.gray05)
                                 .frame(width: 100, height: 100)
                                 .onTapGesture {
-                                    if selectedDots.contains(index) {
-                                        selectedDots.remove(index)
+                                    if selectedDotsArray[currentCellIndex].contains(dotNumber) {
+                                        selectedDotsArray[currentCellIndex].removeAll { $0 == dotNumber }
                                     } else {
-                                        selectedDots.insert(index)
+                                        selectedDotsArray[currentCellIndex].append(dotNumber)
                                     }
                                 }
                         }
@@ -85,7 +106,8 @@ struct PunctuationQuizView: View {
                 
                 HStack(spacing: 17) {
                     Button {
-                        
+                        selectedDotsArray = [[]]
+                        currentCellIndex = 0
                     } label: {
                         RoundedRectangle(cornerRadius: 20)
                             .foregroundStyle(.gray01)
@@ -98,24 +120,28 @@ struct PunctuationQuizView: View {
                     }
                     
                     Button {
-                        
+                        let isCorrect = viewModel.isAnswerCorrect(selectedDotsArray: selectedDotsArray)
+                        coordinator.push(AppDestination.PunctuationResult(isCorrect))
                     } label: {
                         RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.blue01)
+                            .foregroundStyle(isSubmitDisabled ? .gray04 : .blue01)
                             .frame(width: 168, height: 64)
                             .overlay {
                                 Text("작성완료")
                                     .font(.mainTextBold24)
-                                    .foregroundStyle(.white00)
+                                    .foregroundStyle(isSubmitDisabled ? .gray02 : .white00)
                             }
                     }
+                    .disabled(isSubmitDisabled)
                 }
                 .padding(.top, 46)
             }
         }
+        .navigationBarBackButtonHidden(true)
     }
 }
 
 #Preview {
     PunctuationQuizView()
+        .environment(NavigationCoordinator())
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #17 

## 👷 작업한 내용
- PunctuationQuizView UI 구현
- 퀴즈 정답 및 오답 결과 View 구현
- 더미데이터 뷰 모델에 추가
- PunctuationQuizView에서 PunctuationQuizResultView로 화면 전환 구현
- 점자와 닷 UI 매칭 시 array에서 발생하는 문제 해결
- 정답 및 오답확인 로직 구현

## 📸 스크린샷
<img src = "https://github.com/user-attachments/assets/6c9b4e93-a28a-4619-8e4e-bd9be40a445b" width ="250"> 