### PR TITLE
Feat/#34 문장부호 퀴즈 피드백 수정

### DIFF
--- a/LearnDot/Models/WordQuizModel.swift
+++ b/LearnDot/Models/WordQuizModel.swift
@@ -17,17 +17,20 @@ struct QuizData {
 struct BrailleWord {
     let korean: String
     let braillePattern: String
+    let description: String?
     
     // KorToBraille을 사용하여 한글 단어들로부터 점자 패턴을 생성하는 편의 이니셜라이저
-    init(korean: String) {
+    init(korean: String, description: String? = nil) {
         self.korean = korean
         self.braillePattern = KorToBraille.korTranslate(korean)
+        self.description = description
     }
     
     // 미리 계산된 점자 패턴을 직접 지정하는 이니셜라이저 (커스터마이징 필요시)
-    init(korean: String, braillePattern: String) {
-        self.korean = korean
-        self.braillePattern = braillePattern
-    }
+    init(korean: String, braillePattern: String, description: String? = nil) {
+         self.korean = korean
+         self.braillePattern = braillePattern
+         self.description = description
+     }
 }
 

--- a/LearnDot/ViewModels/PunctuationQuizViewModel.swift
+++ b/LearnDot/ViewModels/PunctuationQuizViewModel.swift
@@ -10,22 +10,22 @@ import Foundation
 class PunctuationQuizViewModel: ObservableObject {
     
     let punctuationData: [BrailleWord] = [
-        BrailleWord(korean: "온점 (.)", braillePattern: "⠲"),
-        BrailleWord(korean: "물음표 (?)", braillePattern: "⠦"),
-        BrailleWord(korean: "느낌표 (!)", braillePattern: "⠖"),
-        BrailleWord(korean: "반점 (,)", braillePattern: "⠐"),
-        BrailleWord(korean: "붙임표 (-)", braillePattern: "⠤"),
-        BrailleWord(korean: "빼기 (-)", braillePattern: "⠔"),
-        BrailleWord(korean: "줄표 (—)", braillePattern: "⠤⠤"),
-        BrailleWord(korean: "물결표 (~)", braillePattern: "⠈⠔"),
-        BrailleWord(korean: "별표 (*)", braillePattern: "⠐⠔"),
-        BrailleWord(korean: "여는 큰따옴표 (“)", braillePattern: "⠠⠦"),
-        BrailleWord(korean: "닫는 큰따옴표 (”)", braillePattern: "⠴"),
-        BrailleWord(korean: "여는 작은따옴표 (‘)", braillePattern: "⠠⠦"),
-        BrailleWord(korean: "닫는 작은따옴표 (’)", braillePattern: "⠴⠄"),
-        BrailleWord(korean: "쌍점 (:)", braillePattern: "⠐⠂"),
-        BrailleWord(korean: "세미콜론 (;)", braillePattern: "⠰⠆"),
-        BrailleWord(korean: "줄임표 (…)", braillePattern: "⠠⠠⠠")
+        BrailleWord(korean: "온점 (.)", braillePattern: "⠲", description: "문장 끝을 마무리할 때 사용"),
+        BrailleWord(korean: "물음표 (?)", braillePattern: "⠦", description: "의문을 나타낼 때 사용"),
+        BrailleWord(korean: "느낌표 (!)", braillePattern: "⠖", description: "강조하거나 감탄을 나타낼 때 사용"),
+        BrailleWord(korean: "반점 (,)", braillePattern: "⠐", description: "문장 안에서 잠깐 쉬거나 나열할 때 사용"),
+        BrailleWord(korean: "붙임표 (-)", braillePattern: "⠤", description: "두 단어를 이어주거나 연결할 때 사용"),
+        BrailleWord(korean: "빼기 (-)", braillePattern: "⠔", description: "뺄셈이나 음수를 나타낼 때 사용"),
+        BrailleWord(korean: "줄표 (—)", braillePattern: "⠤⠤", description: "문장 내 구분이나 강조를 위해 사용"),
+        BrailleWord(korean: "물결표 (~)", braillePattern: "⠈⠔", description: "길이나 범위를 나타낼 때 사용"),
+        BrailleWord(korean: "별표 (*)", braillePattern: "⠐⠔", description: "주석이나 강조 표시할 때 사용"),
+        BrailleWord(korean: "여는 큰따옴표 (“)", braillePattern: "⠠⠦", description: "말이나 글을 인용할 때 시작"),
+        BrailleWord(korean: "닫는 큰따옴표 (”)", braillePattern: "⠴", description: "말이나 글을 인용할 때 끝"),
+        BrailleWord(korean: "여는 작은따옴표 (‘)", braillePattern: "⠠⠦", description: "작은 인용이나 강조를 시작할 때"),
+        BrailleWord(korean: "닫는 작은따옴표 (’)", braillePattern: "⠴⠄", description: "작은 인용이나 강조를 끝낼 때"),
+        BrailleWord(korean: "쌍점 (:)", braillePattern: "⠐⠂", description: "목록이나 설명을 시작할 때 사용"),
+        BrailleWord(korean: "세미콜론 (;)", braillePattern: "⠰⠆", description: "두 문장을 연결하거나 나열할 때 사용"),
+        BrailleWord(korean: "줄임표 (…)", braillePattern: "⠠⠠⠠", description: "문장의 일부를 생략하거나 말을 끊어 생략할 때 사용")
     ]
     
     @Published var currentQuiz: BrailleWord? = nil

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
@@ -36,6 +36,7 @@ struct PunctuationQuizView: View {
                         .accessibilityLabel("주어지는 문장부호를 듣고 점자를 찍어보세요.")
                     
                     if let quiz = viewModel.currentQuiz {
+                        let label = quiz.korean + (quiz.description != nil ? ", \(quiz.description!)" : "")
                         RoundedRectangle(cornerRadius: 20)
                             .foregroundStyle(.gray06)
                             .frame(width: 240, height: 72)
@@ -48,6 +49,7 @@ struct PunctuationQuizView: View {
                                     .font(.mainTextSemiBold24)
                                     .foregroundStyle(.white00)
                             }
+                            .accessibilityLabel(label)
                             .padding(.top, 12)
                     }
                 }

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
@@ -13,6 +13,9 @@ struct PunctuationQuizView: View {
     
     @State private var selectedDotsArray: [[Int]] = [[]]
     @State private var currentCellIndex: Int = 0
+    @State private var lastTappedDot: Int? = nil
+    @State private var lastTappedSelected: Bool? = nil
+
     @AccessibilityFocusState private var focusedDot: Int?
     
     let indexToDotNumber = [1, 4, 2, 5, 3, 6]
@@ -76,18 +79,36 @@ struct PunctuationQuizView: View {
                                         GridItem(.fixed(100), spacing: 26)], spacing: 26) {
                         ForEach(0..<6) { index in
                             let dotNumber = indexToDotNumber[index]
+                            let isSelected = selectedDotsArray[currentCellIndex].contains(dotNumber)
+                            
                             Circle()
-                                .fill(selectedDotsArray[currentCellIndex].contains(dotNumber) ? Color.white00 : Color.gray05)
+                                .fill(isSelected ? Color.white00 : Color.gray05)
                                 .frame(width: 100, height: 100)
                                 .onTapGesture {
-                                    if selectedDotsArray[currentCellIndex].contains(dotNumber) {
+                                    if isSelected {
                                         selectedDotsArray[currentCellIndex].removeAll { $0 == dotNumber }
+                                        lastTappedDot = dotNumber
+                                        lastTappedSelected = false
                                     } else {
                                         selectedDotsArray[currentCellIndex].append(dotNumber)
+                                        lastTappedDot = dotNumber
+                                        lastTappedSelected = true
+                                    }
+
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                        lastTappedDot = nil
+                                        lastTappedSelected = nil
                                     }
                                 }
                                 .accessibilityElement()
-                                .accessibilityLabel("\(dotNumber)번 점자")
+                                .accessibilityLabel({
+                                    if let lastDot = lastTappedDot, lastDot == dotNumber,
+                                       let selected = lastTappedSelected {
+                                        return "\(dotNumber)번 점자, \(selected ? "선택됨" : "선택 취소됨")"
+                                    } else {
+                                        return "\(dotNumber)번 점자"
+                                    }
+                                }())
                                 .accessibilitySortPriority(Double(totalDots + 1 - dotNumber))
                                 .accessibilityFocused($focusedDot, equals: dotNumber)
                         }

--- a/LearnDot/Views/WordQuiz/WordQuizView.swift
+++ b/LearnDot/Views/WordQuiz/WordQuizView.swift
@@ -51,8 +51,21 @@ struct WordQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-//                                        .padding(.leading, 0)
+                                        .accessibilityElement()
+                                        .accessibilityLabel(
+                                            quiz.brailleText
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .chunked(into: 1)
+                                                .map { cell in
+                                                    let positions = brailleDotPositions(for: cell.first!)
+                                                    guard !positions.isEmpty else { return "" }
+                                                    return positions.map { "\($0)" }.joined(separator: " ")
+                                                }
+                                                .filter { !$0.isEmpty }
+                                                .joined(separator: "\n다음 cell\n") // 각 셀 구분
+                                        )
                                 }
+
                         case .normal:
                             RoundedRectangle(cornerRadius: 20)
                                 .foregroundStyle(.gray06)
@@ -64,7 +77,19 @@ struct WordQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-//                                        .padding(.leading, 20)
+                                        .accessibilityElement()
+                                        .accessibilityLabel(
+                                            quiz.brailleText
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .chunked(into: 1)
+                                                .map { cell in
+                                                    let positions = brailleDotPositions(for: cell.first!)
+                                                    guard !positions.isEmpty else { return "" }
+                                                    return positions.map { "\($0)" }.joined(separator: " ")
+                                                }
+                                                .filter { !$0.isEmpty }
+                                                .joined(separator: "\n다음 cell\n")
+                                        )
                                 }
                         case .hard:
                             RoundedRectangle(cornerRadius: 20)
@@ -77,7 +102,19 @@ struct WordQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-//                                        .padding(.leading, 20)
+                                        .accessibilityElement()
+                                        .accessibilityLabel(
+                                            quiz.brailleText
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .chunked(into: 1)
+                                                .map { cell in
+                                                    let positions = brailleDotPositions(for: cell.first!)
+                                                    guard !positions.isEmpty else { return "" }
+                                                    return positions.map { "\($0)" }.joined(separator: " ")
+                                                }
+                                                .filter { !$0.isEmpty }
+                                                .joined(separator: "\n다음 cell\n")
+                                        )
                                         .lineLimit(nil)
                                 }
                         }
@@ -118,5 +155,33 @@ struct WordQuizView: View {
             }
         }
         .navigationBarBackButtonHidden()
+    }
+    
+    func brailleDotPositions(for brailleChar: Character) -> [Int] {
+        guard let scalar = brailleChar.unicodeScalars.first else { return [] }
+        let value = scalar.value - 0x2800
+        var positions: [Int] = []
+        for i in 0..<6 {
+            if (value & (1 << i)) != 0 {
+                positions.append(i + 1)
+            }
+        }
+        return positions
+    }
+}
+
+extension String {
+    func chunked(into size: Int) -> [String] {
+        var chunks: [String] = []
+        var current = ""
+        for (i, char) in self.enumerated() {
+            current.append(char)
+            if (i + 1) % size == 0 {
+                chunks.append(current)
+                current = ""
+            }
+        }
+        if !current.isEmpty { chunks.append(current) }
+        return chunks
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #34 

## 👷 작업한 내용
- 셀 점형 번호의 선택여부를 확인할 수 있도록 accessibilityLabel을 수정하였습니다.

> 최초 점 접근은 1번 점자로 호출 / 1번 점자, 선택됨 or 1번 점자, 선택 취소됨

<br> 

- 문장부호의 부연설명을 추가했습니다.

> 아래와 같이 문장부호의 쓰임새를 잘 알 수 있는 부연설명을 추가하였습니다.
```
 BrailleWord(korean: "온점 (.)", braillePattern: "⠲", description: "문장 끝을 마무리할 때 사용"),
        BrailleWord(korean: "물음표 (?)", braillePattern: "⠦", description: "의문을 나타낼 때 사용"),
        BrailleWord(korean: "느낌표 (!)", braillePattern: "⠖", description: "강조하거나 감탄을 나타낼 때 사용"),
        BrailleWord(korean: "반점 (,)", braillePattern: "⠐", description: "문장 안에서 잠깐 쉬거나 나열할 때 사용"),
        BrailleWord(korean: "붙임표 (-)", braillePattern: "⠤", description: "두 단어를 이어주거나 연결할 때 사용"),
        BrailleWord(korean: "빼기 (-)", braillePattern: "⠔", description: "뺄셈이나 음수를 나타낼 때 사용"),
        BrailleWord(korean: "줄표 (—)", braillePattern: "⠤⠤", description: "문장 내 구분이나 강조를 위해 사용"),
        BrailleWord(korean: "물결표 (~)", braillePattern: "⠈⠔", description: "길이나 범위를 나타낼 때 사용"),
        BrailleWord(korean: "별표 (*)", braillePattern: "⠐⠔", description: "주석이나 강조 표시할 때 사용"),
        BrailleWord(korean: "여는 큰따옴표 (“)", braillePattern: "⠠⠦", description: "말이나 글을 인용할 때 시작"),
        BrailleWord(korean: "닫는 큰따옴표 (”)", braillePattern: "⠴", description: "말이나 글을 인용할 때 끝"),
        BrailleWord(korean: "여는 작은따옴표 (‘)", braillePattern: "⠠⠦", description: "작은 인용이나 강조를 시작할 때"),
        BrailleWord(korean: "닫는 작은따옴표 (’)", braillePattern: "⠴⠄", description: "작은 인용이나 강조를 끝낼 때"),
        BrailleWord(korean: "쌍점 (:)", braillePattern: "⠐⠂", description: "목록이나 설명을 시작할 때 사용"),
        BrailleWord(korean: "세미콜론 (;)", braillePattern: "⠰⠆", description: "두 문장을 연결하거나 나열할 때 사용"),
        BrailleWord(korean: "줄임표 (…)", braillePattern: "⠠⠠⠠", description: "문장의 일부를 생략하거나 말을 끊어 생략할 때 사용")
```

<br> 

- 점자 순서 끊어서 읽도록 수정하였습니다.
> 1, 2, 3 다음 셀 3, 4 순으로 읽히도록 수정하였습니다. 
> '\n'을 넣으면 VoiceOver가 다음 문장을 읽기 전에 잠깐 멈추는 부분을 활용해 수정했습니다.


## ❔ 논의 내용
- 이번에 역할 배분에서, 문장부호 퀴즈 파트를 맡았는데 '점자 순서를 끊어서 읽도록' 하는 것은 WordQuizView에서 수정사항으로 알고 있었는데요.ᐟ.ᐟ 잘못 들어가있던 것 같아서, 일단 WordQuizView에서 문제로 출제되는 부분만 수정해놓은 상태이고 확인 후 문제 결과에서 점자 읽을 때 적용하려고 합니다.ᐟ +) 문장부호 퀴즈 파트에서 점자 순서를 끊어읽도록 하는 부분이 있었나요..??