### PR TITLE
[feat] #33 퀴즈 보기 생성 로직 개선

### DIFF
--- a/LearnDot/ViewModels/WordQuizViewModel.swift
+++ b/LearnDot/ViewModels/WordQuizViewModel.swift
@@ -18,54 +18,86 @@ class WordQuizViewModel {
     init(level: DifficultyLevel, category: WordCategory) {
         self.level = level
         self.category = category
-        generateQuize()
+        generateQuiz()
     }
     
-    func generateQuize() {
+    /// 퀴즈 생성
+    /// - Parameters:
+    ///   - correctWord: 미리 정답을 지정할 수도 있음 (nil이면 랜덤)
+    ///   - useBitwise: true면 점자 비트 기반 유사도 비교, false면 기본 문자열 비교
+    func generateQuiz(correctWord: BrailleWord? = nil, useBitwise: Bool = true) {
         isLoading = true
         let sampleWords = getSampleWords(for: level, category: category)
-        
-        guard let correctWord = sampleWords.randomElement() else {
+        guard !sampleWords.isEmpty else {
             isLoading = false
             return
         }
         
-        // 오답 선택지 생성
-        var options = [correctWord.korean]
-        let otherWords = sampleWords.filter { $0.korean != correctWord.korean }
+        // 정답 선택
+        let answerWord = correctWord ?? sampleWords.randomElement()!
         
-        while options.count < 4 && !otherWords.isEmpty {
-            if let randomWord = otherWords.randomElement(),
-               !options.contains(randomWord.korean) {
-                options.append(randomWord.korean)
-            }
+        // 후보 오답 생성
+        let otherWords = sampleWords.filter { $0.korean != answerWord.korean }
+        var similarWords: [BrailleWord]
+        if useBitwise {
+            similarWords = generateSimilarOptionsBitwise(correctWord: answerWord, from: otherWords, count: 3)
+        } else {
+            similarWords = getSimilarOptions(correctWord: answerWord, candidates: otherWords)
         }
         
-        // 부족한 선택지가 있다면 더미 데이터 추가
+        // 옵션: 정답 + 유사 단어
+        var options = [answerWord] + similarWords
+        
+        // 부족하면 무작위로 채우기
         while options.count < 4 {
-            let dummyWord = "선택지\(options.count)"
-            if !options.contains(dummyWord) {
-                options.append(dummyWord)
+            if let randomWord = sampleWords.randomElement(),
+               !options.map(\.korean).contains(randomWord.korean) {
+                options.append(randomWord)
             }
         }
         
         options.shuffle()
         
         currentQuiz = QuizData(
-            brailleText: correctWord.braillePattern,
-            correctAnswer: correctWord.korean,
-            options: options
+            brailleText: answerWord.braillePattern,
+            correctAnswer: answerWord.korean,
+            options: options.map { $0.korean }
         )
         
         isLoading = false
-        
     }
     
     func checkAnswer(_ selectedAnswer: String) -> Bool {
         return selectedAnswer == currentQuiz?.correctAnswer
     }
     
+    // MARK: - 비트 기반 유사 단어 생성
+    private func generateSimilarOptionsBitwise(correctWord: BrailleWord, from words: [BrailleWord], count: Int = 3) -> [BrailleWord] {
+        func brailleToBits(_ braille: String) -> [Int] {
+            return braille.map { $0 == "⠀" ? 0 : 1 }
+        }
+        
+        func hammingDistance(_ a: String, _ b: String) -> Int {
+            let bitsA = brailleToBits(a)
+            let bitsB = brailleToBits(b)
+            let length = min(bitsA.count, bitsB.count)
+            return zip(bitsA.prefix(length), bitsB.prefix(length)).map { $0 == $1 ? 0 : 1 }.reduce(0, +)
+        }
+        
+        let sorted = words
+            .map { ($0, hammingDistance(correctWord.braillePattern, $0.braillePattern)) }
+            .sorted { $0.1 < $1.1 }
+        
+        return Array(sorted.prefix(count).map { $0.0 })
+    }
     
+    // MARK: - 기본 문자열 기반 유사 단어 생성 (간단한 더미)
+    private func getSimilarOptions(correctWord: BrailleWord, candidates: [BrailleWord]) -> [BrailleWord] {
+        // 단순 무작위 3개
+        return Array(candidates.shuffled().prefix(3))
+    }
+    
+    // MARK: - 샘플 단어
     private func getSampleWords(for level: DifficultyLevel, category: WordCategory) -> [BrailleWord] {
         switch category {
         case .food:
@@ -73,12 +105,18 @@ class WordQuizViewModel {
             case .easy:
                 return [
                     BrailleWord(korean: "사과"),
+                    BrailleWord(korean: "석류"),
+                    BrailleWord(korean: "파인애플"),
                     BrailleWord(korean: "포도"),
                     BrailleWord(korean: "귤"),
                     BrailleWord(korean: "딸기"),
+                    BrailleWord(korean: "백도"),
+                    BrailleWord(korean: "블루베리"),
                     BrailleWord(korean: "바나나"),
                     BrailleWord(korean: "수박"),
                     BrailleWord(korean: "배"),
+                    BrailleWord(korean: "감"),
+                    BrailleWord(korean: "밤"),
                     BrailleWord(korean: "복숭아")
                 ]
             case .normal:
@@ -109,8 +147,14 @@ class WordQuizViewModel {
             case .easy:
                 return [
                     BrailleWord(korean: "남자"),
+                    BrailleWord(korean: "남성용"),
+                    BrailleWord(korean: "남녀공용"),
                     BrailleWord(korean: "여자"),
+                    BrailleWord(korean: "여성용"),
+                    BrailleWord(korean: "여아용"),
                     BrailleWord(korean: "화장실"),
+                    BrailleWord(korean: "화장대"),
+                    BrailleWord(korean: "화장품코너"),
                     BrailleWord(korean: "유아용"),
                     BrailleWord(korean: "장애인"),
                     BrailleWord(korean: "비상벨"),
@@ -145,10 +189,20 @@ class WordQuizViewModel {
             case .easy:
                 return [
                     BrailleWord(korean: "서울"),
+                    BrailleWord(korean: "성남"),
+                    BrailleWord(korean: "성신여대"),
                     BrailleWord(korean: "경기"),
+                    BrailleWord(korean: "고양"),
+                    BrailleWord(korean: "광명"),
                     BrailleWord(korean: "대전"),
+                    BrailleWord(korean: "대구"),
+                    BrailleWord(korean: "덕정"),
                     BrailleWord(korean: "부산"),
+                    BrailleWord(korean: "부평"),
+                    BrailleWord(korean: "부천"),
                     BrailleWord(korean: "인천"),
+                    BrailleWord(korean: "일산"),
+                    BrailleWord(korean: "의정부"),
                     BrailleWord(korean: "광주"),
                     BrailleWord(korean: "울산"),
                     BrailleWord(korean: "제주")
@@ -156,12 +210,19 @@ class WordQuizViewModel {
             case .normal:
                 return [
                     BrailleWord(korean: "서울역"),
+                    BrailleWord(korean: "성신여대역"),
+                    BrailleWord(korean: "석계역"),
                     BrailleWord(korean: "공릉역"),
+                    BrailleWord(korean: "고속터미널역"),
+                    BrailleWord(korean: "관악역"),
                     BrailleWord(korean: "부산역"),
                     BrailleWord(korean: "동대구역"),
                     BrailleWord(korean: "수서역"),
                     BrailleWord(korean: "용산역"),
                     BrailleWord(korean: "김포공항"),
+                    BrailleWord(korean: "인천"),
+                    BrailleWord(korean: "일산"),
+                    BrailleWord(korean: "의정부"),
                     BrailleWord(korean: "청량리")
                 ]
             case .hard:
@@ -173,6 +234,7 @@ class WordQuizViewModel {
                     BrailleWord(korean: "노선도"),
                     BrailleWord(korean: "차량번호"),
                     BrailleWord(korean: "정차위치"),
+                    BrailleWord(korean: "승차위치"),
                     BrailleWord(korean: "승차권")
                 ]
             }
@@ -225,7 +287,10 @@ class WordQuizViewModel {
                     BrailleWord(korean: "버튼"),
                     BrailleWord(korean: "리모컨"),
                     BrailleWord(korean: "소리"),
-                    BrailleWord(korean: "밝기")
+                    BrailleWord(korean: "밝기"),
+                    BrailleWord(korean: "스피커"),
+                    BrailleWord(korean: "마이크"),
+                    BrailleWord(korean: "스위치"),
                 ]
             case .normal:
                 return [
@@ -236,7 +301,11 @@ class WordQuizViewModel {
                     BrailleWord(korean: "진동"),
                     BrailleWord(korean: "음소거"),
                     BrailleWord(korean: "배경화면"),
-                    BrailleWord(korean: "데이터")
+                    BrailleWord(korean: "데이터"),
+                    BrailleWord(korean: "사운드"),
+                    BrailleWord(korean: "키보드"),
+                    BrailleWord(korean: "배터리"),
+                    BrailleWord(korean: "아이콘")
                 ]
             case .hard:
                 return [
@@ -247,10 +316,12 @@ class WordQuizViewModel {
                     BrailleWord(korean: "업데이트"),
                     BrailleWord(korean: "시스템복원"),
                     BrailleWord(korean: "네트워크"),
+                    BrailleWord(korean: "와이파이"),
+                    BrailleWord(korean: "스마트폰"),
+                    BrailleWord(korean: "노트북"),
                     BrailleWord(korean: "비밀번호")
                 ]
             }
         }
     }
 }
-

--- a/LearnDot/Views/WordQuiz/BrailleBit.swift
+++ b/LearnDot/Views/WordQuiz/BrailleBit.swift
@@ -1,0 +1,50 @@
+//
+//  BrailleBit.swift
+//  LearnDot
+//
+//  Created by juyeun on 9/22/25.
+//
+
+struct BrailleBit {
+    // 점자 6-dot를 1~63까지 비트로 표현 (여기선 0~63 사용)
+    static let brailleMap: [Character: UInt8] = [
+        "⠀": 0b000000,
+        "⠁": 0b000001, "⠂": 0b000010, "⠃": 0b000011,
+        "⠄": 0b000100, "⠅": 0b000101, "⠆": 0b000110,
+        "⠇": 0b000111, "⠈": 0b001000, "⠉": 0b001001,
+        "⠊": 0b001010, "⠋": 0b001011, "⠌": 0b001100,
+        "⠍": 0b001101, "⠎": 0b001110, "⠏": 0b001111,
+        "⠐": 0b010000, "⠑": 0b010001, "⠒": 0b010010,
+        "⠓": 0b010011, "⠔": 0b010100, "⠕": 0b010101,
+        "⠖": 0b010110, "⠗": 0b010111, "⠘": 0b011000,
+        "⠙": 0b011001, "⠚": 0b011010, "⠛": 0b011011,
+        "⠜": 0b011100, "⠝": 0b011101, "⠞": 0b011110,
+        "⠟": 0b011111, "⠠": 0b100000, "⠡": 0b100001,
+        "⠢": 0b100010, "⠣": 0b100011, "⠤": 0b100100,
+        "⠥": 0b100101, "⠦": 0b100110, "⠧": 0b100111,
+        "⠨": 0b101000, "⠩": 0b101001, "⠪": 0b101010,
+        "⠫": 0b101011, "⠬": 0b101100, "⠭": 0b101101,
+        "⠮": 0b101110, "⠯": 0b101111, "⠰": 0b110000,
+        "⠱": 0b110001, "⠲": 0b110010, "⠳": 0b110011,
+        "⠴": 0b110100, "⠵": 0b110101, "⠶": 0b110110,
+        "⠷": 0b110111, "⠸": 0b111000, "⠹": 0b111001,
+        "⠺": 0b111010, "⠻": 0b111011, "⠼": 0b111100,
+        "⠽": 0b111101, "⠾": 0b111110, "⠿": 0b111111
+    ]
+    
+    static func toBits(_ braille: String) -> [UInt8] {
+        braille.map { brailleMap[$0] ?? 0b000000 }
+    }
+    
+    static func hammingDistance(_ a: String, _ b: String) -> Int {
+        let aBits = toBits(a)
+        let bBits = toBits(b)
+        let maxLength = max(aBits.count, bBits.count)
+        let paddedA = aBits + Array(repeating: 0, count: maxLength - aBits.count)
+        let paddedB = bBits + Array(repeating: 0, count: maxLength - bBits.count)
+        
+        return zip(paddedA, paddedB).reduce(0) { sum, pair in
+            sum + (pair.0 ^ pair.1).nonzeroBitCount
+        }
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
closed #33 

## 👷 작업한 내용
### 퀴즈 보기 생성 로직 개선: 점자 비트 기반 유사도(Hamming Distance) 적용
1. WordQuizViewModel에 generateSimilarOptionsBitwise 메서드 추가
- 점자(braillePattern)를 비트 배열로 변환 후 Hamming Distance를 계산하여 정답과 유사한 보기 3개를 자동 생성
2. generateQuiz 메서드 개선
- 정답 단어 선택 후, 오답은 비트 기반 유사도를 활용하여 추출
- useBitwise 파라미터를 통해 비트 기반/랜덤 기반 방식을 선택 가능
- 옵션 개수가 부족한 경우 무작위 단어를 추가하여 4지선다 보장
3. 기본 문자열 기반 비교(getSimilarOptions)는 fallback 용도로 유지

## 📝 추후 확장 관련
- 추후 GPT API를 연결해 초성 기반 단어 추천 기능으로 확장해보는 것도 논의해보면 좋을 것 같습니다!
