### PR TITLE
[feat] #41 점자 VoiceOver 셀 단위 읽기 개선

### DIFF
--- a/LearnDot/Views/BasicQuiz/BasicQuizResultView.swift
+++ b/LearnDot/Views/BasicQuiz/BasicQuizResultView.swift
@@ -61,7 +61,7 @@ struct BasicQuizResultView: View {
                 
                 // 정답 점자
                 switch unit {
-                case .choseong:
+                case .choseong, .jungseong, .jongseong:
                     ZStack {
                         RoundedRectangle(cornerRadius: 20)
                             .foregroundStyle(.gray06)
@@ -70,6 +70,12 @@ struct BasicQuizResultView: View {
                                 Text(braillePattern.trimmingCharacters(in: ["⠀"]))
                                     .font(.mainTextExtraBold50)
                                     .accessibilitySortPriority(0)
+                                    .accessibilityLabel(
+                                        braillePattern
+                                            .trimmingCharacters(in: ["⠀"])
+                                            .map { String($0) }
+                                            .joined(separator: "\n\n\n")
+                                    )
                             }
                         RoundedRectangle(cornerRadius: 20)
                             .foregroundStyle(.blue00)
@@ -95,106 +101,12 @@ struct BasicQuizResultView: View {
                                     Text(myAnswerBraillePattern.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
                                         .accessibilitySortPriority(0)
-                                }
-                            
-                            RoundedRectangle(cornerRadius: 20)
-                                .foregroundStyle(.blue00)
-                                .frame(width: 76, height: 27)
-                                .overlay {
-                                    Text("내가 고른 답")
-                                        .font(.mainTextSemiBold12)
-                                        .accessibilityLabel("내가 고른 답의 점형")
-                                        .accessibilitySortPriority(1)
-                                }
-                                .padding(.top, -70)
-                                .padding(.leading, -106)
-                        }
-                        .accessibilityElement(children: .combine)
-                    }
-                case .jungseong:
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.gray06)
-                            .frame(width: 240, height: 112)
-                            .overlay {
-                                Text(braillePattern.trimmingCharacters(in: ["⠀"]))
-                                    .font(.mainTextExtraBold50)
-                                    .accessibilitySortPriority(0)
-                            }
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.blue00)
-                            .frame(width: 40, height: 27, alignment: .topLeading)
-                            .overlay {
-                                Text("정답")
-                                    .font(.mainTextSemiBold12)
-                                    .accessibilityLabel("정답 점형")
-                                    .accessibilitySortPriority(1)
-                            }
-                            .padding(.top, -70)
-                            .padding(.leading, -106)
-                    }
-                    .accessibilityElement(children: .combine)
-                    if !isCorrect {
-                        Spacer().frame(height: 22)
-                        
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 20)
-                                .foregroundStyle(.gray06)
-                                .frame(width: 240, height: 112)
-                                .overlay {
-                                    Text(myAnswerBraillePattern.trimmingCharacters(in: ["⠀"]))
-                                        .font(.mainTextExtraBold50)
-                                        .accessibilitySortPriority(0)
-                                }
-                            
-                            RoundedRectangle(cornerRadius: 20)
-                                .foregroundStyle(.blue00)
-                                .frame(width: 76, height: 27)
-                                .overlay {
-                                    Text("내가 고른 답")
-                                        .font(.mainTextSemiBold12)
-                                        .accessibilityLabel("내가 고른 답의 점형")
-                                        .accessibilitySortPriority(1)
-                                }
-                                .padding(.top, -70)
-                                .padding(.leading, -106)
-                        }
-                        .accessibilityElement(children: .combine)
-                    }
-                case .jongseong:
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.gray06)
-                            .frame(width: 240, height: 112)
-                            .overlay {
-                                Text(braillePattern.trimmingCharacters(in: ["⠀"]))
-                                    .font(.mainTextExtraBold50)
-                                    .accessibilitySortPriority(0)
-                            }
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.blue00)
-                            .frame(width: 40, height: 27, alignment: .topLeading)
-                            .overlay {
-                                Text("정답")
-                                    .font(.mainTextSemiBold12)
-                                    .accessibilityLabel("정답 점형")
-                                    .accessibilitySortPriority(1)
-                            }
-                            .padding(.top, -70)
-                            .padding(.leading, -106)
-                    }
-                    .accessibilityElement(children: .combine)
-                    if !isCorrect {
-                        Spacer().frame(height: 22)
-                        
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 20)
-                                .foregroundStyle(.gray06)
-                                .frame(width: 240, height: 112)
-                                .overlay {
-                                    Text(myAnswerBraillePattern.trimmingCharacters(in: ["⠀"]))
-                                        .font(.mainTextExtraBold50)
-                                        .accessibilitySortPriority(0)
+                                        .accessibilityLabel(
+                                            myAnswerBraillePattern
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
+                                        )
                                 }
                             
                             RoundedRectangle(cornerRadius: 20)

--- a/LearnDot/Views/BasicQuiz/BasicQuizView.swift
+++ b/LearnDot/Views/BasicQuiz/BasicQuizView.swift
@@ -49,7 +49,12 @@ struct BasicQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-                                    //                                        .padding(.leading, 0)
+                                        .accessibilityLabel(
+                                            quiz.brailleText
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
+                                        )
                                 }
                         case .jungseong:
                             RoundedRectangle(cornerRadius: 20)
@@ -62,7 +67,12 @@ struct BasicQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-                                    //                                        .padding(.leading, 20)
+                                        .accessibilityLabel(
+                                            quiz.brailleText
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
+                                        )
                                 }
                         case .jongseong:
                             RoundedRectangle(cornerRadius: 20)
@@ -75,7 +85,12 @@ struct BasicQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-                                    //                                        .padding(.leading, 20)
+                                        .accessibilityLabel(
+                                            quiz.brailleText
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
+                                        )
                                         .lineLimit(nil)
                                 }
                         }

--- a/LearnDot/Views/WordQuiz/WordQuizResultView.swift
+++ b/LearnDot/Views/WordQuiz/WordQuizResultView.swift
@@ -70,6 +70,12 @@ struct WordQuizResultView: View {
                             .overlay {
                                 Text(braillePattern.trimmingCharacters(in: ["⠀"]))
                                     .font(.mainTextExtraBold50)
+                                    .accessibilityLabel(
+                                        braillePattern
+                                            .trimmingCharacters(in: ["⠀"])
+                                            .map { String($0) }
+                                            .joined(separator: "\n\n\n")
+                                    )
                                     .accessibilitySortPriority(0)
                             }
                         RoundedRectangle(cornerRadius: 20)
@@ -96,6 +102,12 @@ struct WordQuizResultView: View {
                                     Text(myAnswerBraillePattern.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
                                         .accessibilitySortPriority(0)
+                                        .accessibilityLabel(
+                                            myAnswerBraillePattern
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
+                                        )
                                 }
                             
                             RoundedRectangle(cornerRadius: 20)
@@ -121,6 +133,12 @@ struct WordQuizResultView: View {
                                 Text(braillePattern.trimmingCharacters(in: ["⠀"]))
                                     .font(.mainTextExtraBold50)
                                     .accessibilitySortPriority(0)
+                                    .accessibilityLabel(
+                                        braillePattern
+                                            .trimmingCharacters(in: ["⠀"])
+                                            .map { String($0) }
+                                            .joined(separator: "\n\n\n")
+                                    )
                             }
                         
                         RoundedRectangle(cornerRadius: 20)
@@ -147,6 +165,12 @@ struct WordQuizResultView: View {
                                     Text(myAnswerBraillePattern.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
                                         .accessibilitySortPriority(0)
+                                        .accessibilityLabel(
+                                            myAnswerBraillePattern
+                                                .trimmingCharacters(in: ["⠀"])
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
+                                        )
                                 }
                             
                             RoundedRectangle(cornerRadius: 20)
@@ -172,6 +196,12 @@ struct WordQuizResultView: View {
                                 Text(braillePattern.trimmingCharacters(in: ["⠀"]))
                                     .font(.mainTextExtraBold50)
                                     .accessibilitySortPriority(0)
+                                    .accessibilityLabel(
+                                        braillePattern
+                                            .trimmingCharacters(in: ["⠀"])
+                                            .map { String($0) }
+                                            .joined(separator: "\n\n\n")
+                                    )
                             }
                         
                         RoundedRectangle(cornerRadius: 20)
@@ -198,6 +228,12 @@ struct WordQuizResultView: View {
                                 Text(myAnswerBraillePattern.trimmingCharacters(in: ["⠀"]))
                                     .font(.mainTextExtraBold50)
                                     .accessibilitySortPriority(0)
+                                    .accessibilityLabel(
+                                        myAnswerBraillePattern
+                                            .trimmingCharacters(in: ["⠀"])
+                                            .map { String($0) }
+                                            .joined(separator: "\n\n\n")
+                                    )
                             }
                         
                         RoundedRectangle(cornerRadius: 20)

--- a/LearnDot/Views/WordQuiz/WordQuizView.swift
+++ b/LearnDot/Views/WordQuiz/WordQuizView.swift
@@ -51,21 +51,14 @@ struct WordQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-                                        .accessibilityElement()
                                         .accessibilityLabel(
                                             quiz.brailleText
                                                 .trimmingCharacters(in: ["⠀"])
-                                                .chunked(into: 1)
-                                                .map { cell in
-                                                    let positions = brailleDotPositions(for: cell.first!)
-                                                    guard !positions.isEmpty else { return "" }
-                                                    return positions.map { "\($0)" }.joined(separator: " ")
-                                                }
-                                                .filter { !$0.isEmpty }
-                                                .joined(separator: "\n다음 cell\n") // 각 셀 구분
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
                                         )
                                 }
-
+                            
                         case .normal:
                             RoundedRectangle(cornerRadius: 20)
                                 .foregroundStyle(.gray06)
@@ -77,18 +70,11 @@ struct WordQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-                                        .accessibilityElement()
                                         .accessibilityLabel(
                                             quiz.brailleText
                                                 .trimmingCharacters(in: ["⠀"])
-                                                .chunked(into: 1)
-                                                .map { cell in
-                                                    let positions = brailleDotPositions(for: cell.first!)
-                                                    guard !positions.isEmpty else { return "" }
-                                                    return positions.map { "\($0)" }.joined(separator: " ")
-                                                }
-                                                .filter { !$0.isEmpty }
-                                                .joined(separator: "\n다음 cell\n")
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
                                         )
                                 }
                         case .hard:
@@ -102,18 +88,11 @@ struct WordQuizView: View {
                                 .overlay {
                                     Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
                                         .font(.mainTextExtraBold50)
-                                        .accessibilityElement()
                                         .accessibilityLabel(
                                             quiz.brailleText
                                                 .trimmingCharacters(in: ["⠀"])
-                                                .chunked(into: 1)
-                                                .map { cell in
-                                                    let positions = brailleDotPositions(for: cell.first!)
-                                                    guard !positions.isEmpty else { return "" }
-                                                    return positions.map { "\($0)" }.joined(separator: " ")
-                                                }
-                                                .filter { !$0.isEmpty }
-                                                .joined(separator: "\n다음 cell\n")
+                                                .map { String($0) }
+                                                .joined(separator: "\n\n\n")
                                         )
                                         .lineLimit(nil)
                                 }
@@ -155,33 +134,5 @@ struct WordQuizView: View {
             }
         }
         .navigationBarBackButtonHidden()
-    }
-    
-    func brailleDotPositions(for brailleChar: Character) -> [Int] {
-        guard let scalar = brailleChar.unicodeScalars.first else { return [] }
-        let value = scalar.value - 0x2800
-        var positions: [Int] = []
-        for i in 0..<6 {
-            if (value & (1 << i)) != 0 {
-                positions.append(i + 1)
-            }
-        }
-        return positions
-    }
-}
-
-extension String {
-    func chunked(into size: Int) -> [String] {
-        var chunks: [String] = []
-        var current = ""
-        for (i, char) in self.enumerated() {
-            current.append(char)
-            if (i + 1) % size == 0 {
-                chunks.append(current)
-                current = ""
-            }
-        }
-        if !current.isEmpty { chunks.append(current) }
-        return chunks
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #41 

## 👷 작업한 내용
- VoiceOver에서 점자 글자를 셀 단위로 끊어 읽도록 접근성 라벨 수정
- 점자 문자열 처리에서 기존의 복잡한 도트 변환 제거
- 점자 한 글자(셀)마다 명확히 pause가 느껴지도록 \n\n\n 적용
- WordQuizView, WordQuizResultView, BasicQuizView, BasicQuizResultView에 적용
