### PR TITLE
[refactor] #63 문장부호 리팩토링

### DIFF
--- a/LearnDot/ContentView.swift
+++ b/LearnDot/ContentView.swift
@@ -87,8 +87,8 @@ struct ContentView: View {
                         SavedLearningNumberView()
                     case .savedLearningPunctuationView:
                         SavedLearningPunctuationView()
-                    case .savedLearningWordDetailView(let itemID):
-                        SavedLearningWordDetailView(itemID: itemID)
+                    case .savedLearningWordDetailView(let item): 
+                        SavedLearningWordDetailView(item: item)
                     case .savedLearningAbbreviationView:
                         SavedLearningAbbreviationView()
                     case .translateView:

--- a/LearnDot/Models/WordQuizModel.swift
+++ b/LearnDot/Models/WordQuizModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import KorToBraille
 
 struct QuizData {
-    let brailleText: String // 점자 텍스트 (실제로는 점자 이미지나 점형 패턴)
+    let brailleText: String
     let correctAnswer: String
     let options: [String]
 }
@@ -19,14 +19,12 @@ struct BrailleWord {
     let braillePattern: String
     let description: String?
     
-    // KorToBraille을 사용하여 한글 단어들로부터 점자 패턴을 생성하는 편의 이니셜라이저
     init(korean: String, description: String? = nil) {
         self.korean = korean
         self.braillePattern = KorToBraille.korTranslate(korean)
         self.description = description
     }
     
-    // 미리 계산된 점자 패턴을 직접 지정하는 이니셜라이저 (커스터마이징 필요시)
     init(korean: String, braillePattern: String, description: String? = nil) {
          self.korean = korean
          self.braillePattern = braillePattern

--- a/LearnDot/Resources/NavigationCoordinator.swift
+++ b/LearnDot/Resources/NavigationCoordinator.swift
@@ -61,7 +61,7 @@ enum AppDestination: Hashable {
     case savedLearningLevelView
     case savedLearningPunctuationView
     case savedLearningNumberView
-    case savedLearningWordDetailView(PersistentIdentifier)
+    case savedLearningWordDetailView(SavedLearningItem)
     case savedLearningAbbreviationView
     case translateView
     case abbreviationUnit

--- a/LearnDot/ViewModels/PunctuationQuizViewModel.swift
+++ b/LearnDot/ViewModels/PunctuationQuizViewModel.swift
@@ -19,7 +19,7 @@ class PunctuationQuizViewModel: ObservableObject {
         BrailleWord(korean: "줄표 (—)", braillePattern: "⠤⠤", description: "문장 내 구분이나 강조를 위해 사용"),
         BrailleWord(korean: "물결표 (~)", braillePattern: "⠈⠔", description: "길이나 범위를 나타낼 때 사용"),
         BrailleWord(korean: "별표 (*)", braillePattern: "⠐⠔", description: "주석이나 강조 표시할 때 사용"),
-        BrailleWord(korean: "여는 큰따옴표 (“)", braillePattern: "⠠⠦", description: "말이나 글을 인용할 때 시작"),
+        BrailleWord(korean: "여는 큰따옴표 (“)", braillePattern: "⠦", description: "말이나 글을 인용할 때 시작"),
         BrailleWord(korean: "닫는 큰따옴표 (”)", braillePattern: "⠴", description: "말이나 글을 인용할 때 끝"),
         BrailleWord(korean: "여는 작은따옴표 (‘)", braillePattern: "⠠⠦", description: "작은 인용이나 강조를 시작할 때"),
         BrailleWord(korean: "닫는 작은따옴표 (’)", braillePattern: "⠴⠄", description: "작은 인용이나 강조를 끝낼 때"),

--- a/LearnDot/ViewModels/PunctuationQuizViewModel.swift
+++ b/LearnDot/ViewModels/PunctuationQuizViewModel.swift
@@ -9,6 +9,12 @@ import Foundation
 
 class PunctuationQuizViewModel: ObservableObject {
     
+    private let writingToReadingMap = [
+        1: 4, 4: 1,
+        2: 5, 5: 2,
+        3: 6, 6: 3
+    ]
+    
     let punctuationData: [BrailleWord] = [
         BrailleWord(korean: "온점 (.)", braillePattern: "⠲", description: "문장 끝을 마무리할 때 사용"),
         BrailleWord(korean: "물음표 (?)", braillePattern: "⠦", description: "의문을 나타낼 때 사용"),
@@ -59,15 +65,14 @@ class PunctuationQuizViewModel: ObservableObject {
         
         let correctDotArrays = convertBraillePatternToDotArrays(correctPattern)
         
-        print("🔍 정답 패턴: \(correctPattern)")
-        print("✅ 정답 dot 배열: \(correctDotArrays)")
-        print("📝 입력 dot 배열: \(selectedDotsArray)")
+        let convertedInputArray = selectedDotsArray.map { dots in
+            dots.compactMap { writingToReadingMap[$0] }
+        }
         
-        if selectedDotsArray.count != correctDotArrays.count { return false }
+        if convertedInputArray.count != correctDotArrays.count { return false }
         
-        for (inputDots, correctDots) in zip(selectedDotsArray, correctDotArrays) {
+        for (inputDots, correctDots) in zip(convertedInputArray, correctDotArrays) {
             if Set(inputDots) != Set(correctDots) {
-                print("❌ 불일치: \(inputDots) vs \(correctDots)")
                 return false
             }
         }

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizResultView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizResultView.swift
@@ -175,13 +175,13 @@ struct PunctuationQuizResultView: View {
                 answerInfoText
                     .padding(.top, 8)
                 
-                Text("다음 문제는 맞춰봐요!")
+                Text("점판에 읽을 때는 쓸 때와 좌우가 반전됩니다.")
                     .font(.mainTextSemiBold15)
                     .foregroundStyle(.gray02)
                     .padding(.top, 8)
-                    .accessibilityHidden(true)
             }
             .accessibilityElement(children: .combine)
+            .accessibilitySortPriority(10)
             
             Button(action: {
                 coordinator.pop()
@@ -192,25 +192,28 @@ struct PunctuationQuizResultView: View {
                     .background(Color.gray06)
                     .cornerRadius(20)
                     .foregroundColor(.blue00)
-                    .accessibilityLabel("점자 다시 찍어보기 버튼. 다음으로 넘기면 다음 문제를 풀 수 있고, 두번 탭하면 방금 문제의 점자를 다시 찍어볼 수 있어요.")
             }
             .padding(.top, 20)
+            .accessibilityLabel("점자 다시 찍어보기")
+            .accessibilityHint("방금 문제의 점자를 다시 찍어볼 수 있습니다.")
         }
     }
     
     @ViewBuilder
     private var answerInfoText: some View {
-        Group {
-            Text("정답의 점형 번호는 ")
-                .foregroundStyle(.white00)
-            + Text(dotNumbersText)
-                .foregroundStyle(.blue00)
-                .accessibilityLabel(dotNumbersAccessibilityText)
-            + Text(" 입니다.")
-                .foregroundStyle(.white00)
+        VStack {
+            Group {
+                Text("정답의 점형 번호는 ")
+                    .foregroundStyle(.white00)
+                + Text(dotNumbersText)
+                    .foregroundStyle(.blue00)
+                + Text(" 입니다.")
+                    .foregroundStyle(.white00)
+            }
+            .font(.mainTextSemiBold20)
         }
-        .font(.mainTextSemiBold20)
-        .accessibilityLabel("정답의 점형 번호는 " + correctQuiz.braillePattern.toBrailleDotSpeech() + " 입니다.")
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("정답의 점형 번호는 \(correctQuiz.braillePattern.toBrailleDotSpeech()) 입니다.")
     }
     
     @ViewBuilder
@@ -286,10 +289,11 @@ struct DotCellView: View {
 
     @ViewBuilder
     private func dotCircle(index: Int) -> some View {
-        let dotIndexMapping = [0, 3, 1, 4, 2, 5]
-        let checkIndex = dotIndexMapping[index] + 1
+        let writingLayout = [4, 1, 5, 2, 6, 3]
+        let checkNumber = writingLayout[index]
+        
         Circle()
-            .fill(dotIndexes.contains(checkIndex) ? Color.white00 : Color.gray05)
+            .fill(dotIndexes.contains(checkNumber) ? Color.white00 : Color.gray05)
             .frame(width: 20, height: 20)
     }
 }

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
@@ -18,7 +18,7 @@ struct PunctuationQuizView: View {
 
     @AccessibilityFocusState private var focusedDot: Int?
     
-    let indexToDotNumber = [1, 4, 2, 5, 3, 6]
+    let indexToDotNumber = [4, 1, 5, 2, 6, 3]
     let totalDots = 6
     
     var body: some View {
@@ -30,10 +30,10 @@ struct PunctuationQuizView: View {
             
             VStack(spacing: 0) {
                 VStack(spacing: 0){
-                    Text("다음 문장부호의 점자를 찍어보세요.")
+                    Text("점판에 쓰는 방식으로 찍어보세요.")
                         .font(.mainTextBold24)
                         .foregroundStyle(.blue00)
-                        .accessibilityLabel("주어지는 문장부호를 듣고 점자를 찍어보세요.")
+                        .accessibilityLabel("점판에 쓰는 방식으로, 좌우가 반전된 점자를 찍어보세요. 오른쪽 위가 1번입니다.")
                     
                     if let quiz = viewModel.currentQuiz {
                         let label = quiz.korean + (quiz.description != nil ? ", \(quiz.description!)" : "")

--- a/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
+++ b/LearnDot/Views/PunctuationQuiz/PunctuationQuizView.swift
@@ -33,7 +33,7 @@ struct PunctuationQuizView: View {
                     Text("점판에 쓰는 방식으로 찍어보세요.")
                         .font(.mainTextBold24)
                         .foregroundStyle(.blue00)
-                        .accessibilityLabel("점판에 쓰는 방식으로, 좌우가 반전된 점자를 찍어보세요. 오른쪽 위가 1번입니다.")
+                        .accessibilityLabel("주어진 문장부호를 쓰기 점형으로 찍어보세요. 오른쪽 상단이 1번 점입니다.")
                     
                     if let quiz = viewModel.currentQuiz {
                         let label = quiz.korean + (quiz.description != nil ? ", \(quiz.description!)" : "")

--- a/LearnDot/Views/SavedLearning/SavedLearningAbbreviationView.swift
+++ b/LearnDot/Views/SavedLearning/SavedLearningAbbreviationView.swift
@@ -38,7 +38,7 @@ struct SavedLearningAbbreviationView: View {
                                 SelectLearning(
                                     title: item.word
                                 ) {
-                                    coordinator.push(AppDestination.savedLearningWordDetailView(item.persistentModelID))
+                                    coordinator.push(AppDestination.savedLearningWordDetailView(item))
                                 }
                             }
                         }

--- a/LearnDot/Views/SavedLearning/SavedLearningLevelView.swift
+++ b/LearnDot/Views/SavedLearning/SavedLearningLevelView.swift
@@ -40,7 +40,7 @@ struct SavedLearningLevelView: View {
                                 SelectLearning(
                                     title: item.word
                                 ) {
-                                    coordinator.push(AppDestination.savedLearningWordDetailView(item.persistentModelID))
+                                    coordinator.push(AppDestination.savedLearningWordDetailView(item))
                                 }
                             }
                         }

--- a/LearnDot/Views/SavedLearning/SavedLearningNumberView.swift
+++ b/LearnDot/Views/SavedLearning/SavedLearningNumberView.swift
@@ -42,7 +42,7 @@ struct SavedLearningNumberView: View {
                                 SelectLearning(
                                     title: item.word
                                 ) {
-                                    coordinator.push(AppDestination.savedLearningWordDetailView(item.persistentModelID))
+                                    coordinator.push(AppDestination.savedLearningWordDetailView(item))
                                 }
                             }
                         }

--- a/LearnDot/Views/SavedLearning/SavedLearningPunctuationView.swift
+++ b/LearnDot/Views/SavedLearning/SavedLearningPunctuationView.swift
@@ -40,7 +40,7 @@ struct SavedLearningPunctuationView: View {
                                 SelectLearning(
                                     title: item.word
                                 ) {
-                                    coordinator.push(AppDestination.savedLearningWordDetailView(item.persistentModelID))
+                                    coordinator.push(AppDestination.savedLearningWordDetailView(item))
                                 }
                             }
                         }

--- a/LearnDot/Views/SavedLearning/SavedLearningWordDetailView.swift
+++ b/LearnDot/Views/SavedLearning/SavedLearningWordDetailView.swift
@@ -18,17 +18,10 @@ struct SavedLearningWordDetailView: View {
     
     // MARK: - Data
     
-    @Query var itemQuery: [SavedLearningItem]
+    let item: SavedLearningItem
     
-    private var item: SavedLearningItem? {
-        itemQuery.first
-    }
-    
-    init(itemID: PersistentIdentifier) {
-        let id = itemID
-        self._itemQuery = Query(filter: #Predicate<SavedLearningItem> {
-            $0.persistentModelID == id
-        })
+    init(item: SavedLearningItem) {
+        self.item = item
     }
     
     // MARK: - Body
@@ -37,34 +30,24 @@ struct SavedLearningWordDetailView: View {
         ZStack {
             Color.black00.ignoresSafeArea()
             
-            if let item = item {
-                VStack(spacing: 0) {
-                    
-                    Spacer().frame(height: 30)
-                    
-                    mainCard(item: item)
-                    
-                    Spacer().frame(height: 30)
-                    listenAgainButton(item: item)
-                    
-                    Spacer()
-                }
-            } else {
-                Text("항목을 찾을 수 없습니다.")
-                    .font(.mainTextSemiBold15)
-                    .foregroundStyle(.gray02)
+            VStack(spacing: 0) {
+                Spacer().frame(height: 30)
+                
+                mainCard(item: item)
+                
+                Spacer().frame(height: 30)
+                listenAgainButton(item: item)
+                
+                Spacer()
             }
         }
-        
         .alert("단어 삭제하기", isPresented: $isShowingDeleteAlert) {
             Button("확인", role: .destructive) {
                 deleteItem()
             }
             Button("취소", role: .cancel) {}
         } message: {
-            if let item = item {
-                Text("'\(item.word)' 항목을 삭제할까요?")
-            }
+            Text("'\(item.word)' 항목을 삭제할까요?")
         }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -127,9 +110,8 @@ struct SavedLearningWordDetailView: View {
     // MARK: - Actions
     
     private func deleteItem() {
-        if let item = item {
-            modelContext.delete(item)
-            coordinator.pop()
-        }
+        modelContext.delete(item)
+        try? modelContext.save()
+        coordinator.pop()
     }
 }

--- a/LearnDot/Views/SavedLearning/SavedLearningWordView.swift
+++ b/LearnDot/Views/SavedLearning/SavedLearningWordView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import SwiftData // Import SwiftData
+import SwiftData
 
 struct SavedLearningWordView: View {
     
@@ -38,7 +38,7 @@ struct SavedLearningWordView: View {
                                 SelectLearning(
                                     title: item.word
                                 ) {
-                                    coordinator.push(AppDestination.savedLearningWordDetailView(item.persistentModelID))
+                                    coordinator.push(AppDestination.savedLearningWordDetailView(item))
                                 }
                             }
                         }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #63 
<br>

## 👷 작업한 내용
- **저장된 학습**에서 단어를 최초 확인할 때 단어카드가 없어지는 오류를 수정하였습니다.

```
SwiftData의 임시 ID가 디스크에 저장되는 순간에 영구 ID로 변경되는데, 
이때 ID가 확정되기 전에 리스트 뷰에서 상세 뷰로 넘겨지는데요. 

SavedLearningWordDetailView에서 @Query로 넘겨받은 ID로 데이터를 다시 조회하려고 했으나 
데이터베이스 캐시가 갱신 중이거나, ID가 임시에서 영구로 바뀌는 찰나의 순간에 항목을 찾지 못해 empty 상태로 인식하는 문제였습니다.

그리하여 ID를 전달하는 대신 객체 자체를 전달해, 
데이터베이스를 다시 조회할 필요 없이 메모리에 있는 데이터를 즉시 사용하게 하여 버그를 해결하였습니다 ~ 👾
```

- **점자를 채점하는 기준**이 쓰기 기준으로 채점되도록 수정하였으며, 결과화면에서의 UX 라이팅을 이에 맞게 수정하였습니다.
- `answerInfoText`가 정답을 읽어주는 도중에, 화면 하단의 `brailleCardView`도 포커스를 받아 동시에 소리가 충돌하던 문제를 해결했습니다.
<br>

## 📸 스크린샷
| 화면 | 문장부호 퀴즈 | 퀴즈 결과 |
|:---------:|:---------:|:---------:|
| 15 pro | <img src="https://github.com/user-attachments/assets/3ecce708-494e-4988-af23-a601c92b1fac" width="250"> | <img src="https://github.com/user-attachments/assets/ca2608bd-1d45-4ac0-88c5-eebaf866d7e4" width="250"> | 