### PR TITLE
[Refactor] navigation 리팩토링

### DIFF
--- a/LearnDot/Components/DifficultyLevel.swift
+++ b/LearnDot/Components/DifficultyLevel.swift
@@ -10,7 +10,6 @@ import Foundation
 enum DifficultyLevel {
     case easy
     case normal
-    case hard
 }
 
 enum WordCategory: String, CaseIterable, Identifiable {
@@ -28,31 +27,26 @@ enum WordCategory: String, CaseIterable, Identifiable {
             switch level {
             case .easy: return "과일 이름" // 사과, 포도, 귤, 딸기
             case .normal: return "음식 종류" // 중식, 일식, 한식
-            case .hard: return "카페 인기 음료" // 아메리카노, 카페라떼
             }
         case .restroom:
             switch level {
             case .easy: return "남자/여자 화장실" // 남자, 여자, 화장실, 유아용, 수유실
             case .normal: return "화장실 내 시설" // 세면대, 휴지통, 자동문
-            case .hard: return "상세 지원 도구" // 장애인 호출 버튼, 잠금 장치
             }
         case .transport:
             switch level {
             case .easy: return "지역 이름" // 서울, 경기, 대전, 대구, 부산
             case .normal: return "지하철 역 이름" // 서울역, 공릉역
-            case .hard: return "안내 방송" // 출입문, 종착역, 승강장안내, 하차
             }
         case .medicine:
             switch level {
             case .easy: return "기본 약 이름" // 약, 감기약, 두통약
             case .normal: return "복용 방법" // 식후복용, 하루2번
-            case .hard: return "복잡한 약 정보" // 복약안내, 사용설명서, 약사상담
             }
         case .electronics:
             switch level {
             case .easy: return "전원/볼륨 버튼" // 전원, 볼륨, 재생
             case .normal: return "기능 버튼 설명" // 설정, 메뉴, 저장
-            case .hard: return "기기 설정 용어" // 무선연결, 접근성, 초기화설정
             }
         }
     }

--- a/LearnDot/Resources/NavigationCoordinator.swift
+++ b/LearnDot/Resources/NavigationCoordinator.swift
@@ -23,6 +23,12 @@ class NavigationCoordinator {
     func popToRoot() {
         path.removeLast(path.count)
     }
+
+    func popTo(_ remainingCount: Int) {
+        let removeCount = path.count - remainingCount
+        guard removeCount > 0 else { return }
+        path.removeLast(removeCount)
+    }
 }
 
 // MARK: - Navigation Destinations

--- a/LearnDot/ViewModels/WordQuizViewModel.swift
+++ b/LearnDot/ViewModels/WordQuizViewModel.swift
@@ -154,7 +154,7 @@ class WordQuizViewModel {
                     BrailleWord(korean: "여아용"),
                     BrailleWord(korean: "화장실"),
                     BrailleWord(korean: "화장대"),
-                    BrailleWord(korean: "화장품코너"),
+                    BrailleWord(korean: "화장품"),
                     BrailleWord(korean: "유아용"),
                     BrailleWord(korean: "장애인"),
                     BrailleWord(korean: "비상벨"),

--- a/LearnDot/ViewModels/WordQuizViewModel.swift
+++ b/LearnDot/ViewModels/WordQuizViewModel.swift
@@ -130,17 +130,6 @@ class WordQuizViewModel {
                     BrailleWord(korean: "음료수"),
                     BrailleWord(korean: "샐러드")
                 ]
-            case .hard:
-                return [
-                    BrailleWord(korean: "아메리카노"),
-                    BrailleWord(korean: "카페라떼"),
-                    BrailleWord(korean: "에스프레소"),
-                    BrailleWord(korean: "카푸치노"),
-                    BrailleWord(korean: "티라미수"),
-                    BrailleWord(korean: "마카롱"),
-                    BrailleWord(korean: "브라우니"),
-                    BrailleWord(korean: "젤라또")
-                ]
             }
         case .restroom:
             switch level {
@@ -171,17 +160,6 @@ class WordQuizViewModel {
                     BrailleWord(korean: "휴대용"),
                     BrailleWord(korean: "자동문"),
                     BrailleWord(korean: "여성용")
-                ]
-            case .hard:
-                return [
-                    BrailleWord(korean: "장애인 호출 버튼"),
-                    BrailleWord(korean: "잠금 장치"),
-                    BrailleWord(korean: "비상벨"),
-                    BrailleWord(korean: "손잡이"),
-                    BrailleWord(korean: "경고등"),
-                    BrailleWord(korean: "센서 감지기"),
-                    BrailleWord(korean: "비상 출입문"),
-                    BrailleWord(korean: "긴급 상황")
                 ]
             }
         case .transport:
@@ -225,18 +203,6 @@ class WordQuizViewModel {
                     BrailleWord(korean: "의정부"),
                     BrailleWord(korean: "청량리")
                 ]
-            case .hard:
-                return [
-                    BrailleWord(korean: "출입문"),
-                    BrailleWord(korean: "종착역"),
-                    BrailleWord(korean: "정류장"),
-                    BrailleWord(korean: "운행시간"),
-                    BrailleWord(korean: "노선도"),
-                    BrailleWord(korean: "차량번호"),
-                    BrailleWord(korean: "정차위치"),
-                    BrailleWord(korean: "승차위치"),
-                    BrailleWord(korean: "승차권")
-                ]
             }
         case .medicine:
             switch level {
@@ -261,17 +227,6 @@ class WordQuizViewModel {
                     BrailleWord(korean: "비타민"),
                     BrailleWord(korean: "영양제"),
                     BrailleWord(korean: "소독약")
-                ]
-            case .hard:
-                return [
-                    BrailleWord(korean: "복약안내"),
-                    BrailleWord(korean: "주의사항"),
-                    BrailleWord(korean: "의사소견"),
-                    BrailleWord(korean: "처방전"),
-                    BrailleWord(korean: "복용시간"),
-                    BrailleWord(korean: "금기사항"),
-                    BrailleWord(korean: "약물반응"),
-                    BrailleWord(korean: "장기복용")
                 ]
             }
         case .electronics:
@@ -306,20 +261,6 @@ class WordQuizViewModel {
                     BrailleWord(korean: "키보드"),
                     BrailleWord(korean: "배터리"),
                     BrailleWord(korean: "아이콘")
-                ]
-            case .hard:
-                return [
-                    BrailleWord(korean: "무선연결"),
-                    BrailleWord(korean: "블루투스"),
-                    BrailleWord(korean: "소프트웨어"),
-                    BrailleWord(korean: "운영체제"),
-                    BrailleWord(korean: "업데이트"),
-                    BrailleWord(korean: "시스템복원"),
-                    BrailleWord(korean: "네트워크"),
-                    BrailleWord(korean: "와이파이"),
-                    BrailleWord(korean: "스마트폰"),
-                    BrailleWord(korean: "노트북"),
-                    BrailleWord(korean: "비밀번호")
                 ]
             }
         }

--- a/LearnDot/Views/AbbreviationQuiz/AbbreviationResultView.swift
+++ b/LearnDot/Views/AbbreviationQuiz/AbbreviationResultView.swift
@@ -229,11 +229,12 @@ struct AbbreviationResultView: View {
                 // 학습종료 or 다음문제
                 HStack(spacing: 17) {
                     Button {
-                        coordinator.popToRoot()
+                        // Home → abbreviationUnit → (quiz/result 반복) 중 abbreviationUnit까지 돌아가기
+                        coordinator.popTo(1)
                     } label: {
                         QuitButtonCard()
                     }
-                    
+
                     Button{
                         coordinator.push(AppDestination.abbreviationQuiz(unit))
                     } label: {

--- a/LearnDot/Views/BasicQuiz/BasicQuizResultView.swift
+++ b/LearnDot/Views/BasicQuiz/BasicQuizResultView.swift
@@ -178,11 +178,12 @@ struct BasicQuizResultView: View {
                 
                 HStack(spacing: 17) {
                     Button {
-                        coordinator.popToRoot()
+                        // Home → basicUnit → (quiz/result 반복) 중 basicUnit까지 돌아가기
+                        coordinator.popTo(1)
                     } label: {
                         QuitButtonCard()
                     }
-                    
+
                     Button{
                         coordinator.push(AppDestination.basicQuiz(unit))
                     } label: {

--- a/LearnDot/Views/Onboarding/OnboardingManual0.swift
+++ b/LearnDot/Views/Onboarding/OnboardingManual0.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct OnboardingManual0: View {
     let onNext: () -> Void
-    
+    let onSkip: () -> Void
+
     var body: some View {
         ZStack {
             Color.black00
@@ -57,7 +58,18 @@ struct OnboardingManual0: View {
                     }
                 }
                 
-                Spacer().frame(height: 80)
+                Button {
+                    onSkip()
+                } label: {
+                    Text("설명 건너뛰기")
+                        .font(.mainTextSemiBold15)
+                        .foregroundStyle(.gray02)
+                        .underline()
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 16)
+
+                Spacer().frame(height: 60)
             }
             .padding(.horizontal, 24)
         }
@@ -67,5 +79,7 @@ struct OnboardingManual0: View {
 #Preview {
     OnboardingManual0 {
         print("👉 다음 버튼 눌림")
+    } onSkip: {
+        print("⏭ 건너뛰기 눌림")
     }
 }

--- a/LearnDot/Views/Onboarding/OnboardingManual1.swift
+++ b/LearnDot/Views/Onboarding/OnboardingManual1.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct OnboardingManual1: View {
     let onNext: () -> Void
     let onBack: () -> Void
+    let onSkip: () -> Void
     @AccessibilityFocusState private var isFocused: Bool
     
     var body: some View {
@@ -71,8 +72,19 @@ struct OnboardingManual1: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
-                
-                Spacer().frame(height: 80)
+
+                Button {
+                    onSkip()
+                } label: {
+                    Text("설명 건너뛰기")
+                        .font(.mainTextSemiBold15)
+                        .foregroundStyle(.gray02)
+                        .underline()
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 16)
+
+                Spacer().frame(height: 60)
             }
             .padding(.horizontal, 24)
         }
@@ -91,6 +103,7 @@ struct OnboardingManual1: View {
         print("👉 다음 버튼 눌림")
     } onBack: {
         print("👈 이전 버튼 눌림")
+    } onSkip: {
+        print("⏭ 건너뛰기 눌림")
     }
-    
 }

--- a/LearnDot/Views/Onboarding/OnboardingManual2.swift
+++ b/LearnDot/Views/Onboarding/OnboardingManual2.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct OnboardingManual2: View {
     let onNext: () -> Void
     let onBack: () -> Void
+    let onSkip: () -> Void
     @AccessibilityFocusState private var isFocused: Bool
     
     var body: some View {
@@ -74,8 +75,19 @@ struct OnboardingManual2: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
-                
-                Spacer().frame(height: 80)
+
+                Button {
+                    onSkip()
+                } label: {
+                    Text("설명 건너뛰기")
+                        .font(.mainTextSemiBold15)
+                        .foregroundStyle(.gray02)
+                        .underline()
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 16)
+
+                Spacer().frame(height: 60)
             }
             .padding(.horizontal, 24)
         }
@@ -94,6 +106,7 @@ struct OnboardingManual2: View {
         print("👉 다음 버튼 눌림")
     } onBack: {
         print("👈 이전 버튼 눌림")
+    } onSkip: {
+        print("⏭ 건너뛰기 눌림")
     }
-    
 }

--- a/LearnDot/Views/Onboarding/OnboardingManual3.swift
+++ b/LearnDot/Views/Onboarding/OnboardingManual3.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct OnboardingManual3: View {
     let onNext: () -> Void
     let onBack: () -> Void
+    let onSkip: () -> Void
     @AccessibilityFocusState private var isFocused: Bool
     
     
@@ -79,8 +80,19 @@ struct OnboardingManual3: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
-                
-                Spacer().frame(height: 80)
+
+                Button {
+                    onSkip()
+                } label: {
+                    Text("설명 건너뛰기")
+                        .font(.mainTextSemiBold15)
+                        .foregroundStyle(.gray02)
+                        .underline()
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 16)
+
+                Spacer().frame(height: 60)
             }
             .padding(.horizontal, 24)
         }
@@ -99,6 +111,7 @@ struct OnboardingManual3: View {
         print("👉 다음 버튼 눌림")
     } onBack: {
         print("👈 이전 버튼 눌림")
+    } onSkip: {
+        print("⏭ 건너뛰기 눌림")
     }
-    
 }

--- a/LearnDot/Views/Onboarding/OnboardingManual4.swift
+++ b/LearnDot/Views/Onboarding/OnboardingManual4.swift
@@ -71,7 +71,7 @@ struct OnboardingManual4: View {
                             .foregroundStyle(.blue01)
                             .frame(width: 168, height: 64)
                             .overlay{
-                                Text("설명종료")
+                                Text("설명 종료")
                                     .font(.mainTextBold24)
                                     .foregroundStyle(.white)
                             }
@@ -99,5 +99,4 @@ struct OnboardingManual4: View {
     } onBack: {
         print("👈 이전 버튼 눌림")
     }
-    
 }

--- a/LearnDot/Views/Onboarding/OnboardingView.swift
+++ b/LearnDot/Views/Onboarding/OnboardingView.swift
@@ -26,16 +26,20 @@ struct OnboardingView: View {
             
             switch currentStep {
             case .manual0:
-                OnboardingManual0(onNext: { nextStep() })
+                OnboardingManual0(onNext: { nextStep() },
+                                  onSkip: { finishOnboarding() })
             case .manual1:
                 OnboardingManual1(onNext: { nextStep() },
-                                  onBack: { previousStep() })
+                                  onBack: { previousStep() },
+                                  onSkip: { finishOnboarding() })
             case .manual2:
                 OnboardingManual2(onNext: { nextStep() },
-                                  onBack: { previousStep() })
+                                  onBack: { previousStep() },
+                                  onSkip: { finishOnboarding() })
             case .manual3:
                 OnboardingManual3(onNext: { nextStep() },
-                                  onBack: { previousStep() })
+                                  onBack: { previousStep() },
+                                  onSkip: { finishOnboarding() })
             case .manual4:
                 OnboardingManual4(onNext: { finishOnboarding() },
                                     onBack: { previousStep() })
@@ -58,4 +62,8 @@ struct OnboardingView: View {
     private func finishOnboarding() {
         isFirstLaunching = false
     }
+}
+
+#Preview {
+    OnboardingView()
 }

--- a/LearnDot/Views/WordQuiz/WordLevelView.swift
+++ b/LearnDot/Views/WordQuiz/WordLevelView.swift
@@ -23,7 +23,7 @@ struct WordLevelView: View {
                     Text("난이도")
                         .font(.mainTextExtraBold36)
                         .foregroundStyle(.white00)
-                        .accessibilityLabel("3단계의 난이도 중 하나를 골라주세요")
+                        .accessibilityLabel("2단계의 난이도 중 하나를 골라주세요")
                     
                     Spacer()
                 }
@@ -42,13 +42,6 @@ struct WordLevelView: View {
                         description: "6개 이상의 점자 셀 또는 합성어"
                     ) {
                         coordinator.push(AppDestination.wordCategory(.normal))
-                    }
-                    
-                    SelectCard(
-                        title: "어려움",
-                        description: "외래어, 긴 단어, 추상어"
-                    ) {
-                        coordinator.push(AppDestination.wordCategory(.hard))
                     }
                 }
                 .padding(.top, 30)

--- a/LearnDot/Views/WordQuiz/WordQuizResultView.swift
+++ b/LearnDot/Views/WordQuiz/WordQuizResultView.swift
@@ -283,11 +283,12 @@ struct WordQuizResultView: View {
                 // 학습종료 or 다음문제
                 HStack(spacing: 17) {
                     Button {
-                        coordinator.popToRoot()
+                        // Home → wordLevel → wordCategory → (quiz/result 반복) 중 wordCategory까지 돌아가기
+                        coordinator.popTo(2)
                     } label: {
                         QuitButtonCard()
                     }
-                    
+
                     Button{
                         coordinator.push(AppDestination.wordQuiz(level, category))
                     } label: {

--- a/LearnDot/Views/WordQuiz/WordQuizResultView.swift
+++ b/LearnDot/Views/WordQuiz/WordQuizResultView.swift
@@ -216,59 +216,6 @@ struct WordQuizResultView: View {
                         }
                         .accessibilityElement(children: .combine)
                     }
-                case .hard:
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.gray06)
-                            .frame(width: 345, height: 150)
-                            .overlay {
-                                Text(braillePattern.trimmingCharacters(in: ["⠀"]))
-                                    .font(.mainTextExtraBold50)
-                                    .accessibilitySortPriority(0)
-                                    .accessibilityLabel(braillePattern.toBrailleDotSpeech())
-                            }
-                        
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.blue00)
-                            .frame(width: 40, height: 27)
-                            .overlay {
-                                Text("정답")
-                                    .font(.mainTextSemiBold12)
-                                    .accessibilityLabel("정답 점형")
-                                    .accessibilitySortPriority(1)
-                            }
-                            .padding(.top, -89)
-                            .padding(.leading, -159)
-                    }
-                    .accessibilityElement(children: .combine)
-                    if !isCorrect {
-                        Spacer().frame(height: 22)
-                        
-                        ZStack {
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.gray06)
-                            .frame(width: 345, height: 150)
-                            .overlay {
-                                Text(myAnswerBraillePattern.trimmingCharacters(in: ["⠀"]))
-                                    .font(.mainTextExtraBold50)
-                                    .accessibilitySortPriority(0)
-                                    .accessibilityLabel(myAnswerBraillePattern.toBrailleDotSpeech())
-                            }
-                        
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundStyle(.blue00)
-                            .frame(width: 76, height: 27)
-                            .overlay {
-                                Text("내가 고른 답")
-                                    .font(.mainTextSemiBold12)
-                                    .accessibilityLabel("내가 고른 답의 점형")
-                                    .accessibilitySortPriority(1)
-                            }
-                            .padding(.top, -89)
-                            .padding(.leading, -159)
-                        }
-                        .accessibilityElement(children: .combine)
-                    }
                 }
                 
                 Spacer()

--- a/LearnDot/Views/WordQuiz/WordQuizView.swift
+++ b/LearnDot/Views/WordQuiz/WordQuizView.swift
@@ -67,20 +67,6 @@ struct WordQuizView: View {
                                         .font(.mainTextExtraBold50)
                                         .accessibilityLabel(quiz.brailleText.toBrailleDotSpeech())
                                 }
-                        case .hard:
-                            RoundedRectangle(cornerRadius: 20)
-                                .foregroundStyle(.gray06)
-                                .frame(width: 345, height: 150)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 20)
-                                        .stroke(Color.gray, lineWidth: 1)
-                                )
-                                .overlay {
-                                    Text(quiz.brailleText.trimmingCharacters(in: ["⠀"]))
-                                        .font(.mainTextExtraBold50)
-                                        .accessibilityLabel(quiz.brailleText.toBrailleDotSpeech())
-                                        .lineLimit(nil)
-                                }
                         }
                     }
                     .accessibilityElement(children: .combine)


### PR DESCRIPTION
## 📟 연결된 이슈
closed #65 

## 👷 작업한 내용
  - '학습종료' 버튼 네비게이션 수정: 퀴즈 결과 화면에서 '학습종료' 버튼을 누르면 홈(root)이 아닌, 퀴즈 직전 화면으로 돌아가도록 변경
    - NavigationCoordinator에 popTo(_:) 메서드 추가
    - 기초/약어 ResultView → 단원 선택 화면으로 이동
    - 난이도별 ResultView → 카테고리 선택 화면으로 이동
  - 온보딩 '설명 건너뛰기' 버튼 추가: 온보딩 Manual0~3 페이지 하단에 밑줄 텍스트 버튼을 추가하여, 온보딩을 바로 종료할 수 있도록 개선
  - '어려움' 난이도 삭제: 난이도별 점형학습에서 '어려움' 난이도를 제거하고, 관련 데이터 및 UI를 정리
    - DifficultyLevel에서 .hard 케이스 제거
    - WordLevelView, WordQuizView, WordQuizResultView, WordQuizViewModel에서 관련 코드 삭제
  - 퀴즈 수정(난이도별-쉬움-화장실표시): '화장품코너' → '화장품' 변경 (점자 오타 없음 확인 완료!)

## 📸 스크린샷
<!-- <img src = "" width ="250"> -->
![Simulator Screen Recording - iPhone 16 Pro - 2026-02-26 at 17 24 18](https://github.com/user-attachments/assets/bb7fe0c5-5d32-4cb3-8b67-67597addd6e8)

<img width="250" alt="스크린샷 2026-02-26 오후 4 40 47" src="https://github.com/user-attachments/assets/d27b3bd9-eb30-4694-9140-d26695d7b138" />

